### PR TITLE
[ENGR-331] Create Tailwind Template and Layout for Welcome Emails - POC

### DIFF
--- a/src/components/property_tile_link.html
+++ b/src/components/property_tile_link.html
@@ -1,0 +1,18 @@
+<a href="{{ url }}" class="[text-decoration:none] shadow-md rounded overflow-hidden">
+  <div class="relative">
+    <img class="aspect-video w-full object-cover" src="{{ imgUrl }}"/>
+    <div class="text-slate-700 p-2 shadow-md absolute rounded font-extrabold bg-white bottom-0 right-2">{{price}}</div>
+  </div>
+
+  <div class="text-slate-700 font-semibold p-3 pt-1">
+    <div class="whitespace-nowrap text-ellipsis overflow-hidden">
+      {{ name }}
+    </div>
+    <div class="text-xs whitespace-nowrap text-ellipsis overflow-hidden">
+      {{ address }}
+    </div>
+    <div class="text-xs whitespace-nowrap text-ellipsis overflow-hidden">
+      {{ beds }} | {{ available }}
+    </div>
+  </div>
+</a>

--- a/src/layouts/message.html
+++ b/src/layouts/message.html
@@ -40,7 +40,7 @@
         <td align="center" class="bg-slate-50">
           <table class="w-150 sm:w-full">
             <tr>
-              <td class="px-12 py-12 sm:py-8 sm:px-6 text-left">
+              <td class="px-12 py-12 sm:py-8 sm:px-12 text-left">
                 <a href="https://rentable.co">
                   <img src="https://public-photos.rentable.co/emails/rentable_logo.png" width="120" alt="Maizzle" class="max-w-full align-left [border:0]">
                 </a>

--- a/src/layouts/message.html
+++ b/src/layouts/message.html
@@ -1,0 +1,87 @@
+<!DOCTYPE {{{ page.doctype || 'html' }}}>
+<html lang="{{ page.language || 'en' }}" xmlns:v="urn:schemas-microsoft-com:vml">
+<head>
+  <meta charset="{{ page.charset || 'utf-8' }}">
+  <meta name="x-apple-disable-message-reformatting">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="format-detection" content="telephone=no, date=no, address=no, email=no, url=no">
+  <meta name="color-scheme" content="light dark">
+  <meta name="supported-color-schemes" content="light dark">
+  <!--[if mso]>
+  <noscript>
+    <xml>
+      <o:OfficeDocumentSettings xmlns:o="urn:schemas-microsoft-com:office:office">
+        <o:PixelsPerInch>96</o:PixelsPerInch>
+      </o:OfficeDocumentSettings>
+    </xml>
+  </noscript>
+  <style>
+    td,th,div,p,a,h1,h2,h3,h4,h5,h6 {font-family: "Segoe UI", sans-serif; mso-line-height-rule: exactly;}
+  </style>
+  <![endif]-->
+  <if condition="page.title">
+    <title>{{{ page.title }}}</title>
+  </if>
+  <style>
+    {{{ page.css }}}
+  </style>
+  <block name="head"></block>
+</head>
+<body class="m-0 p-0 w-full [word-break:break-word] [-webkit-font-smoothing:antialiased] {{ page.bodyClass || '' }}">
+  <if condition="page.preheader">
+    <div class="hidden">
+      {{{ page.preheader }}}
+      <each loop="item in Array.from(Array(150))">&#847; </each>
+    </div>
+  </if>
+  <div role="article" aria-roledescription="email" aria-label="{{{ page.title || '' }}}" lang="{{ page.language || 'en' }}">
+    <table class="w-full font-sans">
+      <tr>
+        <td align="center" class="bg-slate-50">
+          <table class="w-150 sm:w-full">
+            <tr>
+              <td class="px-12 py-12 sm:py-8 sm:px-6 text-left">
+                <a href="https://rentable.co">
+                  <img src="https://public-photos.rentable.co/emails/rentable_logo.png" width="120" alt="Maizzle" class="max-w-full align-left [border:0]">
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td align="center" class="sm:px-6">
+                <table class="w-full">
+                  <tr>
+                    <td>
+                      <block name="template"></block>
+                    </td>
+                  </tr>
+                  <tr role="separator">
+                    <td class="h-12"></td>
+                  </tr>
+                  <tr>
+                    <td class="text-center text-slate-600 text-xs px-6 pb-12">
+                      <p class="m-0 italic">
+                        Copyright © 2011– 2022 Rentable, All rights reserved.
+                        <br/>
+                        PO Box 7640, Madison, WI 53707
+                      </p>
+                      <p class="cursor-default">
+                        <a href="https://www.rentable.co" class="text-red-800 [text-decoration:none] hover:[text-decoration:underline]">Visit Rentable</a>
+                        &bull;
+                        <a href="https://www.rentable.co/terms" class="text-red-800 [text-decoration:none] hover:[text-decoration:underline]">Terms</a>
+                        &bull;
+                        <a href="https://www.rentable.co/privacy" class="text-red-800 [text-decoration:none] hover:[text-decoration:underline]">Privacy</a>
+                        &bull;
+                        <a href="https://www.rentable.co/unsubscribe" class="text-red-800 [text-decoration:none] hover:[text-decoration:underline]">Unsubscribe</a>
+                      </p>
+                    </td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </div>
+</body>
+</html>

--- a/src/templates/welcome.html
+++ b/src/templates/welcome.html
@@ -1,0 +1,61 @@
+---
+title: "Welcome to Rentable"
+preheader: ""
+bodyClass: bg-slate-50
+renterName: "Rose"
+marketName: "Madison"
+marketUrl: "https://rentable.co/madison-wi"
+---
+
+<extends src="src/layouts/message.html">
+  <block name="template">
+    <table>
+      <tr>
+        <td align="center" class="sm:px-6">
+          <table class="w-full">
+            <tr>
+              <td class="p-12 sm:px-6 bg-white text-slate-700 text-base text-left leading-6 rounded shadow-sm">
+                <p class="text-2xl sm:leading-8 text-black font-semibold m-0 mb-6">
+                  You’re one step closer to home.
+                </p>
+                <p>
+                  Hi {{{ page.renterName }}},
+                </p>
+                <p>
+                  Thanks for searching with Rentable!
+                </p>
+                <p class="m-0 mb-6">
+                  Get access to thousands of apartments, including properties you won’t find anywhere else.
+                </p>
+                <div class="leading-full">
+                  <a
+                    href="{{{ page.marketUrl }}}"
+                    class="inline-block py-3.5 px-4 rounded text-base font-semibold text-center [text-decoration:none] text-white bg-red-800 hover:bg-red-700"
+                  >
+                    <outlook>
+                      <i class="tracking-6 -mso-font-width-full mso-text-raise-7.5">&#8202;</i>
+                    </outlook>
+                    <span class="mso-text-raise-4">Search {{{ page.marketName }}} Apartments &rarr;</span>
+                    <outlook>
+                      <i class="tracking-6 -mso-font-width-full">&#8202;</i>
+                    </outlook>
+                  </a>
+                </div>
+                <table class="w-full" role="separator">
+                  <tr>
+                    <td class="py-8">
+                      <div class="bg-slate-200 h-px leading-px">&zwnj;</div>
+                    </td>
+                  </tr>
+                </table>
+                <p class="m-0 mb-4">
+                  Thanks, <br />The Rentable Team
+                </p>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </block>
+</extends>

--- a/src/templates/welcome.html
+++ b/src/templates/welcome.html
@@ -4,6 +4,7 @@ preheader: ""
 bodyClass: bg-slate-50
 renterName: "Rose"
 marketName: "Madison"
+marketState: "WI"
 marketUrl: "https://rentable.co/madison-wi"
 ---
 
@@ -27,20 +28,6 @@ marketUrl: "https://rentable.co/madison-wi"
                 <p class="m-0 mb-6">
                   Get access to thousands of apartments, including properties you won’t find anywhere else.
                 </p>
-                <div class="leading-full">
-                  <a
-                    href="{{{ page.marketUrl }}}"
-                    class="inline-block py-3.5 px-4 rounded text-base font-semibold text-center [text-decoration:none] text-white bg-red-800 hover:bg-red-700"
-                  >
-                    <outlook>
-                      <i class="tracking-6 -mso-font-width-full mso-text-raise-7.5">&#8202;</i>
-                    </outlook>
-                    <span class="mso-text-raise-4">Search {{{ page.marketName }}} Apartments &rarr;</span>
-                    <outlook>
-                      <i class="tracking-6 -mso-font-width-full">&#8202;</i>
-                    </outlook>
-                  </a>
-                </div>
                 <table class="w-full" role="separator">
                   <tr>
                     <td class="py-8">
@@ -51,6 +38,73 @@ marketUrl: "https://rentable.co/madison-wi"
                 <p class="m-0 mb-4">
                   Thanks, <br />The Rentable Team
                 </p>
+              </td>
+            </tr>
+            <tr class="mt-12 w-full h-10"></tr>
+            <tr>
+              <td class="p-12 sm:px-6 bg-white text-slate-700 text-base text-left leading-6 rounded shadow-sm">
+                <p class="text-2xl sm:leading-8 text-black font-semibold m-0 mb-6">
+                  Top Apartments in {{{ page.marketName }}}
+                </p>
+                <p>
+                  <div class="grid grid-cols-2 gap-4 sm:grid-cols-1">
+                    <component
+                      src="src/components/property_tile_link.html"
+                      name="Creekside Apartments and Condos"
+                      address="233 Whitney Way, Madison WI"
+                      price="$1,100-2,230"
+                      beds="1-2 BR"
+                      available="Available Now"
+                      url="https://www.rentable.co/madison-wi/the-stadium"
+                      imgUrl="https://images1.apartments.com/i2/tZCAXc6qisBONrIojZCmUMDCCtC0rf516oC9rp9teQo/117/esker-apartments-madison-wi-building-photo.jpg"
+                    ></component>
+                    <component
+                      src="src/components/property_tile_link.html"
+                      name="559 Main Street"
+                      address="Madison WI"
+                      price="$950"
+                      beds="1 BR"
+                      available="Available Mar. 12, 2022"
+                      url="https://www.rentable.co/madison-wi/the-stadium"
+                      imgUrl="https://pyxis.nymag.com/v1/imgs/3b7/66f/9f550fcdabe47c4fd4f7943e4988993522-small-apartment-lede.jpg"
+                    ></component>
+                    <component
+                      src="src/components/property_tile_link.html"
+                      name="Cardinal Apartments"
+                      address="1988 E. Wilson St. Madison, WI"
+                      price="$1,200"
+                      beds="1-2 BR"
+                      available="Available Now"
+                      url="https://www.rentable.co/madison-wi/the-stadium"
+                      imgUrl="https://assets.bwbx.io/images/users/iqjWHBFdfxIU/iNIfKpJ7Z_M0/v1/1200x-1.jpg"
+                    ></component>
+                    <component
+                      src="src/components/property_tile_link.html"
+                      name="The Landing on East Hill Parkway"
+                      address="252 E. Hill Pkway Madison, WI"
+                      price="$1,410-1,725"
+                      beds="Studio-1 BR"
+                      available="Available Jan. 1, 2022"
+                      url="https://www.rentable.co/madison-wi/the-stadium"
+                      imgUrl="https://images1.apartments.com/i2/gS-VYUOs5uTTM_HlCcHxrxGCoTYK42UZ4CXW8bB-nG8/117/novel-midtown-tampa-fl-building-photo.jpg"
+                    ></component>
+                  </div>
+                </p>
+
+                <div class="leading-full">
+                  <a
+                    href="{{{ page.marketUrl }}}"
+                    class="inline-block py-3.5 px-4 mt-2 rounded text-base font-semibold text-center [text-decoration:none] text-white bg-red-800 hover:bg-red-700"
+                  >
+                    <outlook>
+                      <i class="tracking-6 -mso-font-width-full mso-text-raise-7.5">&#8202;</i>
+                    </outlook>
+                    <span class="mso-text-raise-4">Search All {{{ page.marketName }}}, {{{ page.marketState }}} Apartments &rarr;</span>
+                    <outlook>
+                      <i class="tracking-6 -mso-font-width-full">&#8202;</i>
+                    </outlook>
+                  </a>
+                </div>
               </td>
             </tr>
           </table>


### PR DESCRIPTION
We can potentially use Maizzle to quickly develop email client compatible emails with Tailwind. As a proof of concept, I created a basic template for our "Welcome to Rentable" emails.

**Steps to create a new email for the Rails project:**
- check out this repo (abodo-dev/maizzle) and cd into project
- run: 
```
npm install
npm run dev
```
- create new template and/or layout files for new email using Tailwind styles, you can view these in the local dev env (eg. localhost:3001)
- once ready, run `npm run build` -- the "production ready" version of your email will be in the `build_production` folder
- copy email html file from the maizzle project into our rails project as an html.erb file and add any Rails-specific variables/logic (see: https://github.com/abodo-dev/abodo-rails/pull/6689)

Docs:
https://mixandgo.com/learn/ruby-on-rails/email-design-with-tailwindcss
https://maizzle.com/docs/configuration/components

### Screen shots

<img width="700" alt="Screen Shot 2022-12-21 at 5 28 09 PM" src="https://user-images.githubusercontent.com/20048201/209031790-1d62a427-e7c2-4bc4-945e-a773fa260135.png">

